### PR TITLE
fix nvim snippets dir typo

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -20,7 +20,7 @@ endif
 "-------------------------------------------------------------------------------
 " jump to snippets file from anywhere: <leader>cs
 
-if filereadable(expand("~/.config/nvim/snippets.vim"))
+if filereadable(expand("~/.config/nvim/snippets/snippets.vim"))
     source ~/.config/nvim/snippets/snippets.vim
 endif
 


### PR DESCRIPTION
Fix typo of sourcing the snippets.vim file