### PR TITLE
fix xcs alacritty color7 typo

### DIFF
--- a/.scripts/x/xcs
+++ b/.scripts/x/xcs
@@ -392,7 +392,7 @@ def write_alacritty_config(xresources, filename="~/.cache/alacritty/alacritty.ym
                 elif bright and "    cyan:" in line:
                     line = f"    cyan: '{xresources['color14']}'\n"
                 elif (normal or dim) and "    white:" in line:
-                    line = f"    white: '{xresources['color15']}'\n"
+                    line = f"    white: '{xresources['color7']}'\n"
                 elif bright and "    white:" in line:
                     line = f"    white: '{xresources['color15']}'\n"
                 line = line


### PR DESCRIPTION
xcs alacritty color setting typo: there are two `color15` for both dim and bright color.  `color7` and `color15` should fix. 