### PR TITLE
alacritty update: hints for links(http/mailto/ssh..) with keybinding

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -103,11 +103,23 @@ mouse:
   double_click: { threshold: 300 }
   triple_click: { threshold: 300 }
   hide_when_typing: true
-  hints:
-    launcher:
-      program: xdg-open
-      args: []
-    modifiers: None
+  # hints:
+  #   launcher:
+  #     program: xdg-open
+  #     args: []
+  #   modifiers: None
+
+hints:
+  enabled:
+    - regex: "(magnet:|mailto:|gemini:|gopher:|https:|http:|news:|file:|git:|ssh:|ftp:)\
+              [^\u0000-\u001F\u007F-\u009F<>\"\\s{-}\\^⟨⟩`]+"
+      command: xdg-open
+      post_processing: true
+      mouse:
+        enabled: true
+      binding:
+        key: U
+        mods: Control|Shift
 
 mouse_bindings:
   - { mouse: Middle, action: PasteSelection }

--- a/.install/arch_install
+++ b/.install/arch_install
@@ -605,6 +605,8 @@ pacman_install sshfs
 yay_install hfsprogs
 ## testdisk to figure out location HFS+ partition wrapped in 'Apple Core Storage':
 pacman_install testdisk
+## data-at-rest tool: easy-to-use stacked filesystem encryption tool
+pacman_install gocryptfs
 ## webdav filesystem (mount Nextcloud as a folder)
 pacman_install davfs2
 ## recommended settings for davfs2 + Nextcloud


### PR DESCRIPTION
Update with new alacrity hints. For links (https/mailto/ssh...) use key binding (Control|Shift + u) to enable, therefore without hads leaving keyboard for mouse. 

Keybinding choice is from Alacritty repo, can be changed to whatever.
I commented the duplicated section( I think, please correct me if i'm wrong). You can delete the section it they are really the same.