### PR TITLE
nvim: TS start with only installing lua python bash c

### DIFF
--- a/.config/nvim/plugins.vim
+++ b/.config/nvim/plugins.vim
@@ -101,7 +101,7 @@ endif
 lua <<EOF
 require'nvim-treesitter.configs'.setup {
   -- One of "all", "maintained" (parsers with maintainers), or a list of languages
-  ensure_installed = "all",
+  ensure_installed = {"lua", "python", "bash", "c"},
 
   -- Install languages synchronously (only applied to `ensure_installed`)
   sync_install = false,
@@ -114,7 +114,7 @@ require'nvim-treesitter.configs'.setup {
     enable = true,
 
     -- list of language that will be disabled
-    disable = { "bash", "sh", "vim" },
+    disable = {"sh", "vim" },
 
     -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
     -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).


### PR DESCRIPTION
This is the config level version of the [#16](https://github.com/flaport/home/issues/16) fix. 

It installs only `Lua` `python` `bash` `c` at the Treesitter initial install. The drawback will be that we will have to manually install any other language upon use. This fix should be temporary. I will explore a better soluiton. 