### PR TITLE
Nvim treesitter: add more supported languages for syntax highlighting. Disable its indent completely

### DIFF
--- a/.config/nvim/plugins.vim
+++ b/.config/nvim/plugins.vim
@@ -101,7 +101,8 @@ endif
 lua <<EOF
 require'nvim-treesitter.configs'.setup {
   -- One of "all", "maintained" (parsers with maintainers), or a list of languages
-  ensure_installed = {"lua", "python", "bash", "c"},
+  ensure_installed = { "c", "lua", "rust", "python", "bash",
+		"json", "markdown",  "cpp", "jsonc", "css"},
 
   -- Install languages synchronously (only applied to `ensure_installed`)
   sync_install = false,
@@ -114,15 +115,15 @@ require'nvim-treesitter.configs'.setup {
     enable = true,
 
     -- list of language that will be disabled
-    disable = {"sh", "vim" },
+    disable = {"sh", "vim", "toml", "yaml" },
 
     -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
     -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
     -- Using this option may slow down your editor, and you may see some duplicate highlights.
     -- Instead of true it can also be a list of languages
-    additional_vim_regex_highlighting = { "bash", "sh", "vim" },
+    additional_vim_regex_highlighting = { "toml","yaml", "sh", "vim" },
   },
-  indent = { enable = true, disable = { "yaml" } },
+  indent = { enable = false, disable = { "toml", "yaml", "python" } },
 }
 EOF
 


### PR DESCRIPTION
Now supported languages are "c", "lua", "rust", "python", "bash", "yaml", "json", "markdown", "toml", "cpp", "jsonc", "css".
Within, yaml and toml is diabled since there are already syntax highlighting plugins for them. (pls correct me is I'm wrong)

Additionally, indent functionality is disabled completely for treesitter. All indentation will be completed by neovim itself.