### PR TITLE
hide dunst notification while screen locked

### DIFF
--- a/.config/picom/picom.conf
+++ b/.config/picom/picom.conf
@@ -23,6 +23,8 @@ backend = "glx"
 #
 # no-use-damage = false
 use-damage = true;
+# hide dunst notifications while screen is locked
+unredir-if-possible=true;
 
 #################################
 #             Shadows           #


### PR DESCRIPTION
Dunst notifications are now in front of the locked screen. This should fix it.