### PR TITLE
nvim: indent scope and indent blankline updates

### DIFF
--- a/.config/nvim/lua/plugins/modules/indent-blankline.lua
+++ b/.config/nvim/lua/plugins/modules/indent-blankline.lua
@@ -1,13 +1,16 @@
 return {
     "lukas-reineke/indent-blankline.nvim",
-    tag = "v2.20.8",
     event = { "BufReadPost", "BufNewFile" },
     enabled = true,
-    opts = {
-        -- char = "▏",
-        char = "│",
-        filetype_exclude = { "help", "alpha", "dashboard", "neo-tree", "Trouble", "lazy" },
-        show_trailing_blankline_indent = false,
-        show_current_context = false,
-    },
+    config = function ()
+        require("ibl").setup {
+            debounce = 50,
+            indent = { char = "╎" },
+            exclude = { filetypes = {"help", "alpha", "dashboard", "neo-tree", "Trouble", "lazy", "undotree"} },
+            whitespace = {
+                remove_blankline_trail = true,
+            },
+            scope = { enabled = false },
+        }
+    end
 }

--- a/.config/nvim/lua/plugins/modules/indent-blankline.lua
+++ b/.config/nvim/lua/plugins/modules/indent-blankline.lua
@@ -4,7 +4,7 @@ return {
     enabled = true,
     config = function ()
         require("ibl").setup {
-            debounce = 50,
+            debounce = 300,
             indent = { char = "╎" },
             exclude = { filetypes = {"help", "alpha", "dashboard", "neo-tree", "Trouble", "lazy", "undotree"} },
             whitespace = {

--- a/.config/nvim/lua/plugins/modules/indentscope.lua
+++ b/.config/nvim/lua/plugins/modules/indentscope.lua
@@ -3,13 +3,15 @@ return {
     version = false,
     event = { "BufReadPre", "BufNewFile" },
     opts = {
-        -- symbol = "▏",
-        symbol = "│",
+        symbol = "┃",
         options = { try_as_border = true },
+        draw = {
+            delay = 50, -- Delay (in ms) between event and start of drawing scope indicator
+        },
     },
     init = function()
         vim.api.nvim_create_autocmd("FileType", {
-            pattern = { "help", "alpha", "dashboard", "neo-tree", "Trouble", "lazy", "mason" },
+            pattern = { "help", "alpha", "dashboard", "neo-tree", "Trouble", "lazy", "mason", "undotree" },
             callback = function()
                 vim.b.miniindentscope_disable = true
             end,

--- a/.config/nvim/lua/plugins/modules/indentscope.lua
+++ b/.config/nvim/lua/plugins/modules/indentscope.lua
@@ -1,6 +1,7 @@
 return {
     "echasnovski/mini.indentscope",
     version = false,
+    enabled = true,
     event = { "BufReadPre", "BufNewFile" },
     opts = {
         symbol = "┃",


### PR DESCRIPTION
- Indent-blankline updated to 3.x. This PR updates the configuration part to adapt to the new API. 
- This PR also gives cosmetic changes to the indent-scope plugin. No major effect/function changes.